### PR TITLE
Fix docker compose env vars and mysql2 native build

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1429,9 +1429,10 @@ export async function runStep12(
 
     onProgress(5, 'Starting docker compose...')
     const composeCwd = path.join(REPO_PATH, '.local-dev')
-    await sh(`${composeCmd} up -d --force-recreate`, {
+    await sh(`direnv exec "${composeCwd}" ${composeCmd} up -d --force-recreate`, {
       cwd: composeCwd,
-      interactive: true
+      interactive: true,
+      env: { REPO_ROOT: REPO_PATH }
     })
 
     // 5. Wait for MySQL
@@ -1440,8 +1441,9 @@ export async function runStep12(
     const retryInterval = 15
     let mysqlHealthy = false
     for (let i = 0; i < maxRetries; i++) {
-      const containerId = await sh(`${composeCmd} ps -q mysql 2>/dev/null || echo ""`, {
-        cwd: composeCwd
+      const containerId = await sh(`direnv exec "${composeCwd}" ${composeCmd} ps -q mysql 2>/dev/null || echo ""`, {
+        cwd: composeCwd,
+        env: { REPO_ROOT: REPO_PATH }
       })
       const cid = containerId.stdout.trim()
       if (cid) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1373,21 +1373,24 @@ export async function runStep12(
 
     // mysql2 gem with library flags (platform-aware)
     const buildFlags = await getLibBuildFlags((cmd) => sh(cmd))
+
+    // Bundle config for native gem compilation — set before any gem install so
+    // both the standalone gem install and bundle install pick up the right flags.
+    // Needed on all macOS (not just ARM) with MySQL 9.x which requires zstd.
+    if (isDarwin() || isLinux()) {
+      await sh(
+        `bundle config set --global build.mysql2 "--with-opt-dir=${buildFlags.optDir} --with-ldflags=${buildFlags.ldflags} --with-cppflags=${buildFlags.cppflags}"`,
+        { cwd: path.join(REPO_PATH, 'backend') }
+      )
+    }
+
     await sh(
-      `gem install mysql2 -- --with-ldflags="${buildFlags.ldflags}" --with-cppflags="${buildFlags.cppflags}"`,
+      `gem install mysql2 -- --with-opt-dir="${buildFlags.optDir}" --with-ldflags="${buildFlags.ldflags}" --with-cppflags="${buildFlags.cppflags}"`,
       { cwd: path.join(REPO_PATH, 'backend') }
     )
 
     // tmuxinator (terminal multiplexer session manager)
     await sh('gem install tmuxinator')
-
-    // Bundle config for native gem compilation
-    if (isArm() || isLinux()) {
-      await sh(
-        `bundle config --global build.mysql2 "--with-opt-dir=${buildFlags.optDir} --with-ldflags=${buildFlags.ldflags} --with-cppflags=${buildFlags.cppflags}"`,
-        { cwd: path.join(REPO_PATH, 'backend') }
-      )
-    }
 
     await sh('bundle install', { cwd: path.join(REPO_PATH, 'backend'), interactive: true })
 


### PR DESCRIPTION
## Changes

### Fix docker compose: pass REPO_ROOT env and use direnv exec to load .envrc variables
- `docker compose up` and `docker compose ps` were failing because env vars from `.local-dev/.envrc` (e.g. `WORDPRESS_URL`, `API_HOST`, etc.) were not loaded when running programmatically
- Wrapped compose commands with `direnv exec` to source the `.envrc` before execution
- Explicitly passed `REPO_ROOT` env var (needed by the compose files that include `it-management/common/docker-compose.yml`)

### Fix mysql2 build: add --with-opt-dir, set bundle config before gem install, apply on all macOS
- `ld: library 'zstd' not found` error when building the `mysql2` gem against MySQL 9.x (Homebrew)
- Added `--with-opt-dir` (openssl path) to the standalone `gem install mysql2` invocation
- Moved `bundle config set build.mysql2` to run **before** `gem install` so both code paths pick up the flags
- Changed guard from `isArm() || isLinux()` to `isDarwin() || isLinux()` — Intel Macs with MySQL 9.x hit the same zstd issue