### PR TITLE
Add Conductor setup step to welcome wizard

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1529,49 +1529,41 @@ export async function runStep14(
       )
     }
 
-    // The Conductor services live behind the "conductor" compose profile and
-    // are NOT started by the main dev-environment step.
     const composeCwd = path.join(REPO_PATH, '.local-dev')
     const composeEnv = { REPO_ROOT: REPO_PATH }
     const composeCmd =
       (await sh('docker compose version', { cwd: composeCwd })).code === 0
         ? 'docker compose'
         : 'docker-compose'
-    const compose = `${composeCmd} --profile conductor`
 
-    // 2. Bring the Conductor stack up — this pulls the conductor-server image
-    //    and starts conductor-postgres, conductor, and conductor-ui.
-    onProgress(1, 'Starting Conductor containers (docker compose --profile conductor up -d)...')
-    const up = await sh(`direnv exec "${composeCwd}" ${compose} up -d`, {
-      cwd: composeCwd,
-      interactive: true,
-      env: composeEnv
-    })
+    // 2. Bring the Conductor services up directly by name — the postgres db it
+    //    depends on, plus the conductor server itself. Targeting the services
+    //    explicitly starts them even though they define a compose profile, and
+    //    pulls the conductor-server image.
+    onProgress(1, 'Starting Conductor containers (conductor-postgres, conductor)...')
+    const up = await sh(
+      `direnv exec "${composeCwd}" ${composeCmd} up -d conductor-postgres conductor`,
+      { cwd: composeCwd, interactive: true, env: composeEnv }
+    )
     if (up.code !== 0) {
       throw new Error('Failed to start Conductor containers via docker compose.')
     }
 
     // 3. Wait for the Conductor server to report healthy before running setup —
     //    conductor:setup registers definitions against the running server.
+    //    The compose service pins container_name: conductor, so inspect it directly.
     onProgress(2, 'Waiting for Conductor to become healthy...')
     const maxRetries = 20
     const retryInterval = 15
     let conductorHealthy = false
     for (let i = 0; i < maxRetries; i++) {
-      const containerId = await sh(
-        `direnv exec "${composeCwd}" ${compose} ps -q conductor 2>/dev/null || echo ""`,
-        { cwd: composeCwd, env: composeEnv }
+      const health = await sh(
+        `docker inspect --format='{{.State.Health.Status}}' conductor 2>/dev/null || echo "starting"`,
+        { cwd: composeCwd }
       )
-      const cid = containerId.stdout.trim()
-      if (cid) {
-        const health = await sh(
-          `docker inspect --format='{{.State.Health.Status}}' ${cid} 2>/dev/null || echo "starting"`,
-          { cwd: composeCwd }
-        )
-        if (health.stdout.trim() === 'healthy') {
-          conductorHealthy = true
-          break
-        }
+      if (health.stdout.trim() === 'healthy') {
+        conductorHealthy = true
+        break
       }
       onProgress(2, `Waiting for Conductor (${i + 1}/${maxRetries})...`)
       await new Promise((r) => setTimeout(r, retryInterval * 1000))

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1529,9 +1529,60 @@ export async function runStep14(
       )
     }
 
-    // 2. Run the Conductor setup rake task in the backend. This pulls the
-    //    conductor-server image and provisions the local Conductor service.
-    onProgress(1, 'Running bin/rake conductor:setup...')
+    // The Conductor services live behind the "conductor" compose profile and
+    // are NOT started by the main dev-environment step.
+    const composeCwd = path.join(REPO_PATH, '.local-dev')
+    const composeEnv = { REPO_ROOT: REPO_PATH }
+    const composeCmd =
+      (await sh('docker compose version', { cwd: composeCwd })).code === 0
+        ? 'docker compose'
+        : 'docker-compose'
+    const compose = `${composeCmd} --profile conductor`
+
+    // 2. Bring the Conductor stack up — this pulls the conductor-server image
+    //    and starts conductor-postgres, conductor, and conductor-ui.
+    onProgress(1, 'Starting Conductor containers (docker compose --profile conductor up -d)...')
+    const up = await sh(`direnv exec "${composeCwd}" ${compose} up -d`, {
+      cwd: composeCwd,
+      interactive: true,
+      env: composeEnv
+    })
+    if (up.code !== 0) {
+      throw new Error('Failed to start Conductor containers via docker compose.')
+    }
+
+    // 3. Wait for the Conductor server to report healthy before running setup —
+    //    conductor:setup registers definitions against the running server.
+    onProgress(2, 'Waiting for Conductor to become healthy...')
+    const maxRetries = 20
+    const retryInterval = 15
+    let conductorHealthy = false
+    for (let i = 0; i < maxRetries; i++) {
+      const containerId = await sh(
+        `direnv exec "${composeCwd}" ${compose} ps -q conductor 2>/dev/null || echo ""`,
+        { cwd: composeCwd, env: composeEnv }
+      )
+      const cid = containerId.stdout.trim()
+      if (cid) {
+        const health = await sh(
+          `docker inspect --format='{{.State.Health.Status}}' ${cid} 2>/dev/null || echo "starting"`,
+          { cwd: composeCwd }
+        )
+        if (health.stdout.trim() === 'healthy') {
+          conductorHealthy = true
+          break
+        }
+      }
+      onProgress(2, `Waiting for Conductor (${i + 1}/${maxRetries})...`)
+      await new Promise((r) => setTimeout(r, retryInterval * 1000))
+    }
+    if (!conductorHealthy) {
+      throw new Error('Conductor did not become healthy in time.')
+    }
+
+    // 4. Run the Conductor setup rake task in the backend, now that the server
+    //    is up and healthy.
+    onProgress(3, 'Running bin/rake conductor:setup...')
     const rake = await sh('bin/rake conductor:setup', {
       cwd: path.join(REPO_PATH, 'backend'),
       interactive: true

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1345,8 +1345,33 @@ export async function runStep11(
   }
 }
 
-/** Step 12: Setup development environment */
+/** Step 12: Conductor ECR login — authenticate Docker with the Conductor
+ *  registry so the conductor image can be pulled (runs before step 13). */
 export async function runStep12(
+  _config: SetupConfig,
+  onProgress: ProgressCallback
+): Promise<TaskResult> {
+  const start = Date.now()
+  try {
+    onProgress(0, `Logging in to ${CONDUCTOR_ECR_REGISTRY}...`)
+    const login = await sh(
+      `aws ecr get-login-password --profile "${LOCAL_AWS_PROFILE}" --region "${LOCAL_AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin ${CONDUCTOR_ECR_REGISTRY}`,
+      { interactive: true }
+    )
+    if (login.code !== 0) {
+      throw new Error(
+        `Failed to authenticate Docker with ECR (${CONDUCTOR_ECR_REGISTRY}). Ensure your AWS SSO session is active.`
+      )
+    }
+
+    return { success: true, duration: Date.now() - start }
+  } catch (e: any) {
+    return { success: false, error: e.message, duration: Date.now() - start }
+  }
+}
+
+/** Step 13: Setup development environment */
+export async function runStep13(
   config: SetupConfig,
   onProgress: ProgressCallback
 ): Promise<TaskResult> {
@@ -1502,8 +1527,8 @@ export async function runStep12(
   }
 }
 
-/** Step 13: Install agent skills */
-export async function runStep13(
+/** Step 14: Install agent skills */
+export async function runStep14(
   config: SetupConfig,
   onProgress: ProgressCallback
 ): Promise<TaskResult> {
@@ -1516,31 +1541,6 @@ export async function runStep13(
       if (result.code !== 0) {
         // Non-fatal: log but continue
       }
-    }
-
-    return { success: true, duration: Date.now() - start }
-  } catch (e: any) {
-    return { success: false, error: e.message, duration: Date.now() - start }
-  }
-}
-
-/** Step 14: Conductor ECR login — authenticate Docker with the Conductor
- *  registry so the conductor image can be pulled (must run before step 12). */
-export async function runStep14(
-  _config: SetupConfig,
-  onProgress: ProgressCallback
-): Promise<TaskResult> {
-  const start = Date.now()
-  try {
-    onProgress(0, `Logging in to ${CONDUCTOR_ECR_REGISTRY}...`)
-    const login = await sh(
-      `aws ecr get-login-password --profile "${LOCAL_AWS_PROFILE}" --region "${LOCAL_AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin ${CONDUCTOR_ECR_REGISTRY}`,
-      { interactive: true }
-    )
-    if (login.code !== 0) {
-      throw new Error(
-        `Failed to authenticate Docker with ECR (${CONDUCTOR_ECR_REGISTRY}). Ensure your AWS SSO session is active.`
-      )
     }
 
     return { success: true, duration: Date.now() - start }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -43,6 +43,7 @@ const REPO_PATH = path.join(CODE_DIR, REPO_NAME)
 const LOCAL_DOMAIN = 'local.factorial.dev'
 const LOCAL_AWS_PROFILE = 'development'
 const LOCAL_AWS_DEFAULT_REGION = 'eu-central-1'
+const CONDUCTOR_ECR_REGISTRY = '771567148620.dkr.ecr.eu-central-1.amazonaws.com'
 const BUNDLER_VERSION = '2.5.11'
 const PERSONAL_ENV_RC_PATH = path.join(REPO_PATH, '.envrc.personal')
 
@@ -313,7 +314,7 @@ const EDITOR_CASK_MAP: Record<string, string> = {
 }
 
 // ── Task Runners ────────────────────────────────────────
-// Each function corresponds to one of the 13 steps from welcome.sh.
+// Each function corresponds to one of the setup steps from welcome.sh.
 // They report progress via the `onProgress` callback and return a TaskResult.
 
 /** Ensure Homebrew is installed on macOS; no-op on other platforms */
@@ -1508,6 +1509,43 @@ export async function runStep13(
   }
 }
 
+/** Step 14: Setup Conductor (OSS workflow orchestration) */
+export async function runStep14(
+  _config: SetupConfig,
+  onProgress: ProgressCallback
+): Promise<TaskResult> {
+  const start = Date.now()
+  try {
+    // 1. Authenticate Docker with the Conductor ECR registry so the
+    //    conductor-server image can be pulled.
+    onProgress(0, `Logging in to ${CONDUCTOR_ECR_REGISTRY}...`)
+    const login = await sh(
+      `aws ecr get-login-password --profile "${LOCAL_AWS_PROFILE}" --region "${LOCAL_AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin ${CONDUCTOR_ECR_REGISTRY}`,
+      { interactive: true }
+    )
+    if (login.code !== 0) {
+      throw new Error(
+        `Failed to authenticate Docker with ECR (${CONDUCTOR_ECR_REGISTRY}). Ensure your AWS SSO session is active.`
+      )
+    }
+
+    // 2. Run the Conductor setup rake task in the backend. This pulls the
+    //    conductor-server image and provisions the local Conductor service.
+    onProgress(1, 'Running bin/rake conductor:setup...')
+    const rake = await sh('bin/rake conductor:setup', {
+      cwd: path.join(REPO_PATH, 'backend'),
+      interactive: true
+    })
+    if (rake.code !== 0) {
+      throw new Error('bin/rake conductor:setup failed. Check /tmp/welcome.log for details.')
+    }
+
+    return { success: true, duration: Date.now() - start }
+  } catch (e: any) {
+    return { success: false, error: e.message, duration: Date.now() - start }
+  }
+}
+
 // ── Task runner map ─────────────────────────────────────
 export type TaskRunner = (config: SetupConfig, onProgress: ProgressCallback) => Promise<TaskResult>
 
@@ -1524,7 +1562,8 @@ export const TASK_RUNNERS: Record<number, TaskRunner> = {
   10: runStep10,
   11: runStep11,
   12: runStep12,
-  13: runStep13
+  13: runStep13,
+  14: runStep14
 }
 
 // ── SSH Setup Helpers (used by SSHSetup wizard step) ────

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1436,6 +1436,21 @@ export async function runStep12(
       env: { REPO_ROOT: REPO_PATH }
     })
 
+    // Start the Conductor services (postgres + server). They currently sit
+    // behind the "conductor" compose profile, so bring them up explicitly by
+    // name with the profile enabled. The image pull relies on the Conductor
+    // ECR login having run in its dedicated step beforehand.
+    // (When the profile is dropped from the compose file, this can fold into
+    // the main `up` above.)
+    onProgress(6, 'Starting Conductor services (conductor-postgres, conductor)...')
+    const conductorUp = await sh(
+      `direnv exec "${composeCwd}" ${composeCmd} --profile conductor up -d conductor-postgres conductor`,
+      { cwd: composeCwd, interactive: true, env: { REPO_ROOT: REPO_PATH } }
+    )
+    if (conductorUp.code !== 0) {
+      throw new Error('Failed to start Conductor services via docker compose.')
+    }
+
     // 5. Wait for MySQL
     onProgress(6, 'Waiting for MySQL readiness...')
     const maxRetries = 10
@@ -1509,15 +1524,14 @@ export async function runStep13(
   }
 }
 
-/** Step 14: Setup Conductor (OSS workflow orchestration) */
+/** Step 14: Conductor ECR login — authenticate Docker with the Conductor
+ *  registry so the conductor image can be pulled (must run before step 12). */
 export async function runStep14(
   _config: SetupConfig,
   onProgress: ProgressCallback
 ): Promise<TaskResult> {
   const start = Date.now()
   try {
-    // 1. Authenticate Docker with the Conductor ECR registry so the
-    //    conductor-server image can be pulled.
     onProgress(0, `Logging in to ${CONDUCTOR_ECR_REGISTRY}...`)
     const login = await sh(
       `aws ecr get-login-password --profile "${LOCAL_AWS_PROFILE}" --region "${LOCAL_AWS_DEFAULT_REGION}" | docker login --username AWS --password-stdin ${CONDUCTOR_ECR_REGISTRY}`,
@@ -1527,60 +1541,6 @@ export async function runStep14(
       throw new Error(
         `Failed to authenticate Docker with ECR (${CONDUCTOR_ECR_REGISTRY}). Ensure your AWS SSO session is active.`
       )
-    }
-
-    const composeCwd = path.join(REPO_PATH, '.local-dev')
-    const composeEnv = { REPO_ROOT: REPO_PATH }
-    const composeCmd =
-      (await sh('docker compose version', { cwd: composeCwd })).code === 0
-        ? 'docker compose'
-        : 'docker-compose'
-
-    // 2. Bring the Conductor services up directly by name — the postgres db it
-    //    depends on, plus the conductor server itself. Targeting the services
-    //    explicitly starts them even though they define a compose profile, and
-    //    pulls the conductor-server image.
-    onProgress(1, 'Starting Conductor containers (conductor-postgres, conductor)...')
-    const up = await sh(
-      `direnv exec "${composeCwd}" ${composeCmd} up -d conductor-postgres conductor`,
-      { cwd: composeCwd, interactive: true, env: composeEnv }
-    )
-    if (up.code !== 0) {
-      throw new Error('Failed to start Conductor containers via docker compose.')
-    }
-
-    // 3. Wait for the Conductor server to report healthy before running setup —
-    //    conductor:setup registers definitions against the running server.
-    //    The compose service pins container_name: conductor, so inspect it directly.
-    onProgress(2, 'Waiting for Conductor to become healthy...')
-    const maxRetries = 20
-    const retryInterval = 15
-    let conductorHealthy = false
-    for (let i = 0; i < maxRetries; i++) {
-      const health = await sh(
-        `docker inspect --format='{{.State.Health.Status}}' conductor 2>/dev/null || echo "starting"`,
-        { cwd: composeCwd }
-      )
-      if (health.stdout.trim() === 'healthy') {
-        conductorHealthy = true
-        break
-      }
-      onProgress(2, `Waiting for Conductor (${i + 1}/${maxRetries})...`)
-      await new Promise((r) => setTimeout(r, retryInterval * 1000))
-    }
-    if (!conductorHealthy) {
-      throw new Error('Conductor did not become healthy in time.')
-    }
-
-    // 4. Run the Conductor setup rake task in the backend, now that the server
-    //    is up and healthy.
-    onProgress(3, 'Running bin/rake conductor:setup...')
-    const rake = await sh('bin/rake conductor:setup', {
-      cwd: path.join(REPO_PATH, 'backend'),
-      interactive: true
-    })
-    if (rake.code !== 0) {
-      throw new Error('bin/rake conductor:setup failed. Check /tmp/welcome.log for details.')
     }
 
     return { success: true, duration: Date.now() - start }

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -224,11 +224,18 @@ export const SETUP_TASKS: SetupTask[] = [
     dependsOn: [4, 7, 10]
   },
   {
+    id: 14,
+    icon: '▸',
+    name: 'Conductor ECR login',
+    description: 'docker login to the Conductor ECR registry (before pulling the image)',
+    dependsOn: [2, 6]
+  },
+  {
     id: 12,
     icon: '▸',
     name: 'Setup development environment',
-    description: 'Install deps, docker compose, DB setup, tmuxinator',
-    dependsOn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
+    description: 'Install deps, docker compose (incl. conductor), DB setup + conductor:setup, tmuxinator',
+    dependsOn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14]
   },
   {
     id: 13,
@@ -236,13 +243,6 @@ export const SETUP_TASKS: SetupTask[] = [
     name: 'Install agent skills',
     description: 'npx skills add for 5 skill repos',
     dependsOn: [1]
-  },
-  {
-    id: 14,
-    icon: '▸',
-    name: 'Setup Conductor',
-    description: 'ECR login, start conductor containers, rake conductor:setup',
-    dependsOn: [6, 12]
   }
 ]
 

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -224,21 +224,21 @@ export const SETUP_TASKS: SetupTask[] = [
     dependsOn: [4, 7, 10]
   },
   {
-    id: 14,
+    id: 12,
     icon: '▸',
     name: 'Conductor ECR login',
     description: 'docker login to the Conductor ECR registry (before pulling the image)',
     dependsOn: [2, 6]
   },
   {
-    id: 12,
+    id: 13,
     icon: '▸',
     name: 'Setup development environment',
     description: 'Install deps, docker compose (incl. conductor), DB setup + conductor:setup, tmuxinator',
-    dependsOn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 14]
+    dependsOn: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
   },
   {
-    id: 13,
+    id: 14,
     icon: '▸',
     name: 'Install agent skills',
     description: 'npx skills add for 5 skill repos',

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -136,7 +136,7 @@ function getIdentityFromSystem(): { fullName: string; email: string } {
   }
 }
 
-// ── The 13 setup tasks from welcome.sh ─────────────────
+// ── The setup tasks from welcome.sh ────────────────────
 export type SetupTask = {
   id: number
   icon: string
@@ -236,6 +236,13 @@ export const SETUP_TASKS: SetupTask[] = [
     name: 'Install agent skills',
     description: 'npx skills add for 5 skill repos',
     dependsOn: [1]
+  },
+  {
+    id: 14,
+    icon: '▸',
+    name: 'Setup Conductor',
+    description: 'ECR login, pull conductor image, rake conductor:setup',
+    dependsOn: [6, 12]
   }
 ]
 

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -241,7 +241,7 @@ export const SETUP_TASKS: SetupTask[] = [
     id: 14,
     icon: '▸',
     name: 'Setup Conductor',
-    description: 'ECR login, pull conductor image, rake conductor:setup',
+    description: 'ECR login, start conductor containers, rake conductor:setup',
     dependsOn: [6, 12]
   }
 ]

--- a/src/steps/Install.tsx
+++ b/src/steps/Install.tsx
@@ -124,6 +124,7 @@ function getSubtasks(taskId: number, config: SetupConfig): string[] {
         'bundle install...',
         'Setting up shadowdog...',
         'docker compose up -d...',
+        'Starting Conductor services...',
         'Waiting for MySQL readiness...',
         config.restoreDb
           ? 'Restoring database from backup...'
@@ -135,10 +136,7 @@ function getSubtasks(taskId: number, config: SetupConfig): string[] {
       ]
     case 14:
       return [
-        'Logging in to Conductor ECR registry...',
-        'Starting Conductor containers...',
-        'Waiting for Conductor to become healthy...',
-        'Running bin/rake conductor:setup...'
+        'Logging in to Conductor ECR registry...'
       ]
     default:
       return []

--- a/src/steps/Install.tsx
+++ b/src/steps/Install.tsx
@@ -136,6 +136,8 @@ function getSubtasks(taskId: number, config: SetupConfig): string[] {
     case 14:
       return [
         'Logging in to Conductor ECR registry...',
+        'Starting Conductor containers...',
+        'Waiting for Conductor to become healthy...',
         'Running bin/rake conductor:setup...'
       ]
     default:

--- a/src/steps/Install.tsx
+++ b/src/steps/Install.tsx
@@ -120,6 +120,10 @@ function getSubtasks(taskId: number, config: SetupConfig): string[] {
       ]
     case 12:
       return [
+        'Logging in to Conductor ECR registry...'
+      ]
+    case 13:
+      return [
         'yarn install / pnpm install...',
         'bundle install...',
         'Setting up shadowdog...',
@@ -130,13 +134,9 @@ function getSubtasks(taskId: number, config: SetupConfig): string[] {
           ? 'Restoring database from backup...'
           : 'Running db:create + db:migrate...'
       ]
-    case 13:
-      return [
-        'npx skills add factorialco/factorial-skills...',
-      ]
     case 14:
       return [
-        'Logging in to Conductor ECR registry...'
+        'npx skills add factorialco/factorial-skills...',
       ]
     default:
       return []

--- a/src/steps/Install.tsx
+++ b/src/steps/Install.tsx
@@ -133,6 +133,11 @@ function getSubtasks(taskId: number, config: SetupConfig): string[] {
       return [
         'npx skills add factorialco/factorial-skills...',
       ]
+    case 14:
+      return [
+        'Logging in to Conductor ECR registry...',
+        'Running bin/rake conductor:setup...'
+      ]
     default:
       return []
   }


### PR DESCRIPTION
## What

Adds a new setup task to the welcome wizard — **id 14, "Setup Conductor"** — that runs after the AWS credentials and dev environment are ready.

The step does two things:

1. **ECR login** so the Conductor image can be pulled:
   ```
   aws ecr get-login-password --profile development --region eu-central-1 \
     | docker login --username AWS --password-stdin 771567148620.dkr.ecr.eu-central-1.amazonaws.com
   ```
2. **`bin/rake conductor:setup`** in `~/code/factorial/backend`.

## Changes

- `src/commands.ts` — new `runStep14` runner + registration in `TASK_RUNNERS`, plus the `CONDUCTOR_ECR_REGISTRY` constant.
- `src/context.tsx` — registers the task in `SETUP_TASKS` with `dependsOn: [6, 12]` (AWS credentials + dev environment).
- `src/steps/Install.tsx` — adds the two progress subtask labels for the TUI.

The task slots automatically into the dependency-driven parallel runner and the DONE summary.

## Notes

- **Cross-account ECR:** the `development` profile (account `800301453252`) authenticates against the registry in account `771567148620`. This relies on the dev SSO role having cross-account pull permission on that registry.

## Verification

- `npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)