### PR TITLE
Remove profile option from Conductor service startup command in runStep13

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1469,7 +1469,7 @@ export async function runStep13(
     // the main `up` above.)
     onProgress(6, 'Starting Conductor services (conductor-postgres, conductor)...')
     const conductorUp = await sh(
-      `direnv exec "${composeCwd}" ${composeCmd} --profile conductor up -d conductor-postgres conductor`,
+      `direnv exec "${composeCwd}" ${composeCmd} up -d conductor-postgres conductor`,
       { cwd: composeCwd, interactive: true, env: { REPO_ROOT: REPO_PATH } }
     )
     if (conductorUp.code !== 0) {


### PR DESCRIPTION
After merged https://github.com/factorialco/factorial/pull/100896 no more profile is needed.