### PR TITLE
Bump Rust version to 1.96.0

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -779,8 +779,8 @@ export async function runStep5(
       }
 
       // 6. Install rust specific version
-      onProgress(5, 'Installing Rust 1.88.0...')
-      await sh('mise use -g rust@1.88.0')
+      onProgress(5, 'Installing Rust 1.96.0...')
+      await sh('mise use -g rust@1.96.0')
 
       // 7. Install all versions from repo
       onProgress(6, 'Installing all versions from .tool-versions...')
@@ -803,7 +803,7 @@ export async function runStep5(
       }
 
       onProgress(5, 'Installing Rust...')
-      await sh('asdf install rust', { env: { ASDF_RUST_VERSION: '1.88.0' } })
+      await sh('asdf install rust', { env: { ASDF_RUST_VERSION: '1.96.0' } })
 
       onProgress(6, 'Installing all versions from .tool-versions...')
       await sh('asdf install', { cwd: REPO_PATH, interactive: true })


### PR DESCRIPTION
## What

Updates the Rust version installed by the welcome wizard (Step 5) from **1.88.0** to **1.96.0**.

## Why

Verified that the welcome script was still pinned to Rust **1.88.0**, not 1.96.0. This bumps it to the intended version.

## Changes

In `src/commands.ts` (`runStep5`):
- **mise path**: `mise use -g rust@1.88.0` → `rust@1.96.0` (and the progress label)
- **asdf path**: `ASDF_RUST_VERSION` `1.88.0` → `1.96.0`