### PR TITLE
Fix agent skills task hanging on npx install prompt

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1540,7 +1540,7 @@ export async function runStep14(
     for (let i = 0; i < SKILL_REPOS.length; i++) {
       const repo = SKILL_REPOS[i]!
       onProgress(i, `npx skills add ${repo}...`)
-      const result = await sh(`npx skills add "${repo}" -g -y`, { interactive: true })
+      const result = await sh(`npx --yes skills add "${repo}" -g -y`, { interactive: true })
       if (result.code !== 0) {
         // Non-fatal: log but continue
       }


### PR DESCRIPTION
npx prompts to install the `skills` package, but the `-y` flag was being passed to `skills add` rather than to npx itself. Under the Ink TUI (raw-mode stdin, piped stdout) the prompt was invisible and unanswerable, so task 14 hung indefinitely and the wizard stalled. Add `npx --yes` to auto-confirm.

## 🚪 Why?

[why]: # (✍️ _What needs is this Pull Request solving or how is it improving the product?_)

The "Install agent skills" task (step 14) hangs forever, stalling the wizard near completion. `npx skills add ...` triggers npx's own "Need to install the following packages… Ok to proceed?" prompt. The existing `-y` flag is consumed by the `skills add` subcommand, not npx, so npx blocks on stdin. Since the install phase runs under Ink (raw-mode stdin) with child stdout piped to a log, the prompt is never shown and can't be answered — the task never resolves and the user is stuck.

## 🔑 What?

[what]: # (✍️ _What changes is this Pull Request introducing in the code?_)

Pass `--yes` to npx itself so the package install is auto-confirmed and never prompts:

```diff
- npx skills add "${repo}" -g -y
+ npx --yes skills add "${repo}" -g -y