### PR TITLE
Fix/dx retro setup fixes

### DIFF
--- a/bin/welcome.mjs
+++ b/bin/welcome.mjs
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
-import { register } from 'tsx/esm/api'
 
-// Register tsx loader so we can import .tsx files directly
+// Pre-bootstrap Node version gate: fail fast with a clear message before
+// loading tsx/Ink, which would otherwise crash cryptically on an old Node.
+const MIN_NODE_MAJOR = 18
+const major = Number(process.versions.node.split('.')[0])
+if (Number.isNaN(major) || major < MIN_NODE_MAJOR) {
+  console.error(
+    `\nFactorial welcome needs Node.js >= ${MIN_NODE_MAJOR} (you have ${process.versions.node}).`
+  )
+  console.error('Install a newer Node (https://nodejs.org or `brew install node`) and re-run.\n')
+  process.exit(1)
+}
+
+// Dynamic imports run after the gate (static imports would hoist above it).
+const { register } = await import('tsx/esm/api')
 register()
-
-// Now import and run the app
 await import('../src/index.tsx')

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "factorial-welcome": "./bin/welcome.mjs"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "start": "tsx src/index.tsx",
     "build": "tsc",

--- a/src/commands/preflight.ts
+++ b/src/commands/preflight.ts
@@ -10,10 +10,22 @@ export type PreflightResult = {
   message: string
 }
 
+const MIN_NODE_MAJOR = 18
+
 /** Detect the user's shell */
 async function checkShell(): Promise<PreflightResult> {
   const shell = getUserShell()
   return { name: 'Shell', status: 'ok', message: shell }
+}
+
+/** Check Node.js version (warn if < 18). Covers the local `npm start` path. */
+async function checkNodeVersion(): Promise<PreflightResult> {
+  const version = process.versions.node
+  const major = Number(version.split('.')[0])
+  if (Number.isNaN(major) || major < MIN_NODE_MAJOR) {
+    return { name: 'Node.js', status: 'warn', message: `${version} (< ${MIN_NODE_MAJOR} required)` }
+  }
+  return { name: 'Node.js', status: 'ok', message: version }
 }
 
 /** Check macOS version (warn if < 13 Ventura). Skip on Linux. */
@@ -114,7 +126,14 @@ async function checkNetwork(): Promise<PreflightResult> {
 export async function runPreflightChecks(
   onResult: (result: PreflightResult, index: number) => void
 ): Promise<PreflightResult[]> {
-  const checks = [checkShell, checkOSVersion, checkAdmin, checkDiskSpace, checkNetwork]
+  const checks = [
+    checkShell,
+    checkNodeVersion,
+    checkOSVersion,
+    checkAdmin,
+    checkDiskSpace,
+    checkNetwork,
+  ]
   const results: PreflightResult[] = []
 
   for (let i = 0; i < checks.length; i++) {

--- a/src/commands/steps/04-clone-repo.ts
+++ b/src/commands/steps/04-clone-repo.ts
@@ -36,12 +36,33 @@ export async function runStep4(
         1,
         `Cloning factorialco/factorial into ${REPO_PATH}... (this may take a while, patience!)`
       )
-      const result = await sh(
-        `git clone git@github.com:${ORG_NAME}/${REPO_NAME}.git "${REPO_PATH}"`,
-        { interactive: true }
-      )
-      if (result.code !== 0) {
-        throw new Error('Failed to clone Factorial repository')
+      // Resilient clone (I2):
+      //  - `--filter=blob:none` makes a blobless partial clone: file contents are
+      //    fetched on demand instead of all at once, so the initial transfer is
+      //    much smaller and far less likely to stall/time out on a flaky network.
+      //  - Retry with backoff so a transient network blip doesn't fail the whole
+      //    setup. A failed clone can leave a partial dir behind, which would make
+      //    the next attempt fail with "already exists", so we clean it each retry.
+      const maxAttempts = 3
+      let cloned = false
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        const result = await sh(
+          `git clone --filter=blob:none git@github.com:${ORG_NAME}/${REPO_NAME}.git "${REPO_PATH}"`,
+          { interactive: true }
+        )
+        if (result.code === 0) {
+          cloned = true
+          break
+        }
+        // Clean up any partial clone so the retry starts from a clean state.
+        await sh(`rm -rf "${REPO_PATH}"`)
+        if (attempt < maxAttempts) {
+          onProgress(1, `Clone failed (attempt ${attempt}/${maxAttempts}), retrying...`)
+          await new Promise((r) => setTimeout(r, attempt * 5000))
+        }
+      }
+      if (!cloned) {
+        throw new Error(`Failed to clone Factorial repository after ${maxAttempts} attempts`)
       }
     } else if (await dirExists(path.join(REPO_PATH, '.git'))) {
       onProgress(1, 'Repository already cloned, pulling latest...')

--- a/src/commands/steps/04-clone-repo.ts
+++ b/src/commands/steps/04-clone-repo.ts
@@ -36,13 +36,7 @@ export async function runStep4(
         1,
         `Cloning factorialco/factorial into ${REPO_PATH}... (this may take a while, patience!)`
       )
-      // Resilient clone (I2):
-      //  - `--filter=blob:none` makes a blobless partial clone: file contents are
-      //    fetched on demand instead of all at once, so the initial transfer is
-      //    much smaller and far less likely to stall/time out on a flaky network.
-      //  - Retry with backoff so a transient network blip doesn't fail the whole
-      //    setup. A failed clone can leave a partial dir behind, which would make
-      //    the next attempt fail with "already exists", so we clean it each retry.
+      // Blobless partial clone + retry with backoff for flaky networks
       const maxAttempts = 3
       let cloned = false
       for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -54,7 +48,7 @@ export async function runStep4(
           cloned = true
           break
         }
-        // Clean up any partial clone so the retry starts from a clean state.
+        // Clean the partial clone so the retry doesn't hit "already exists"
         await sh(`rm -rf "${REPO_PATH}"`)
         if (attempt < maxAttempts) {
           onProgress(1, `Clone failed (attempt ${attempt}/${maxAttempts}), retrying...`)

--- a/src/commands/steps/05-version-manager.ts
+++ b/src/commands/steps/05-version-manager.ts
@@ -40,8 +40,11 @@ export async function runStep5(
       onProgress(1, 'Setting up mise version manager...')
       await ensureLine(shellRc, `eval "$(mise activate ${shell})"`)
 
-      // Disable python-build's GitHub attestation check (fails on many networks)
-      await sh('mise settings set python.github_attestations false', { check: true })
+      // Best-effort: disable python-build's GitHub attestation check (older mise lacks this key)
+      const attestations = await sh('mise settings set python.github_attestations false')
+      if (attestations.code !== 0) {
+        onProgress(1, '⚠ Could not set python.github_attestations (continuing)')
+      }
 
       // 2-5. Install plugins
       for (let i = 0; i < plugins.length; i++) {

--- a/src/commands/steps/05-version-manager.ts
+++ b/src/commands/steps/05-version-manager.ts
@@ -40,11 +40,7 @@ export async function runStep5(
       onProgress(1, 'Setting up mise version manager...')
       await ensureLine(shellRc, `eval "$(mise activate ${shell})"`)
 
-      // Disable python-build's GitHub attestation verification (I3). Newer
-      // python-build verifies the downloaded CPython source against GitHub
-      // attestations; on many networks that extra fetch/verify step fails and
-      // aborts the whole python install. Persist the setting before any python
-      // install so both `mise use python@latest` and `mise install` are safe.
+      // Disable python-build's GitHub attestation check (fails on many networks)
       await sh('mise settings set python.github_attestations false', { check: true })
 
       // 2-5. Install plugins

--- a/src/commands/steps/05-version-manager.ts
+++ b/src/commands/steps/05-version-manager.ts
@@ -40,6 +40,13 @@ export async function runStep5(
       onProgress(1, 'Setting up mise version manager...')
       await ensureLine(shellRc, `eval "$(mise activate ${shell})"`)
 
+      // Disable python-build's GitHub attestation verification (I3). Newer
+      // python-build verifies the downloaded CPython source against GitHub
+      // attestations; on many networks that extra fetch/verify step fails and
+      // aborts the whole python install. Persist the setting before any python
+      // install so both `mise use python@latest` and `mise install` are safe.
+      await sh('mise settings set python.github_attestations false', { check: true })
+
       // 2-5. Install plugins
       for (let i = 0; i < plugins.length; i++) {
         onProgress(i + 1, `Installing plugin: ${plugins[i]}...`)

--- a/src/commands/steps/14-agent-skills.ts
+++ b/src/commands/steps/14-agent-skills.ts
@@ -2,6 +2,15 @@ import { type SetupConfig } from '../../context/index.js'
 import { SKILL_REPOS } from '../constants.js'
 import { getErrorMessage, sh, type ProgressCallback, type TaskResult } from '../helpers.js'
 
+// Hard backstop so a stuck `skills add` is killed and skipped, not hung
+const SKILL_INSTALL_TIMEOUT_MS = 3 * 60 * 1000
+
+// Force non-interactive git/SSH so a clone fails fast instead of waiting on a prompt
+const NON_INTERACTIVE_GIT_ENV = {
+  GIT_TERMINAL_PROMPT: '0',
+  GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
+}
+
 /** Step 14: Install agent skills */
 export async function runStep14(
   config: SetupConfig,
@@ -14,9 +23,12 @@ export async function runStep14(
       onProgress(i, `npx skills add ${repo}...`)
       const result = await sh(`npx --yes skills add "${repo}" -g -y`, {
         interactive: true,
+        timeout: SKILL_INSTALL_TIMEOUT_MS,
+        env: NON_INTERACTIVE_GIT_ENV,
       })
       if (result.code !== 0) {
-        // Non-fatal: log but continue
+        // Non-fatal: warn and continue so one bad skill doesn't block setup
+        onProgress(i, `⚠ Skipped "${repo}" (skills add failed or timed out) — continuing.`)
       }
     }
 


### PR DESCRIPTION
### Why

First-time local setup breaks in ways that are hard to diagnose, turning a routine npx welcome run into a debugging session. The failure modes this PR targets:

A flaky network during the repository clone aborts the entire setup on the first hiccup, with no retry — and the clone pulls every blob up front, maximizing the window for a stall.
The python install dies on python-build's GitHub-attestation verification (an extra fetch/verify step that fails on many networks), taking the whole version-manager step down with it.
The agent-skills step can hang forever: the underlying skills add git clone blocks on a prompt that is invisible (and unanswerable) under the Ink TUI.
An unsupported Node version crashes cryptically deep inside tsx/Ink instead of saying "you need Node ≥ 18" up front.
Each of these is a quiet, late, hard-to-attribute failure. This PR makes the fragile steps fail fast with clear messages, retry transient failures, and never hang.

### What

Resilient repository clone (src/commands/steps/04-clone-repo.ts): clone with --filter=blob:none (blobless partial clone — file contents fetched on demand, so the initial transfer is far smaller and less likely to stall), and retry up to 3× with linear backoff (5s, 10s). A failed clone can leave a partial dir behind, so it's cleaned (rm -rf) before each retry to avoid "already exists". Fails loud only after all attempts are exhausted.
Disable python GitHub attestations on mise (src/commands/steps/05-version-manager.ts): set python.github_attestations=false (mise settings set) before any python install, so both mise use python@latest and mise install are safe. Best-effort — older mise versions don't recognize the setting and would error, so a failed set warns and continues instead of taking the step down.
Harden agent-skills install (src/commands/steps/14-agent-skills.ts): add a 3-minute per-skill timeout as a hard backstop (a stuck skill is killed and skipped, not hung) and force non-interactive git/SSH (GIT_TERMINAL_PROMPT=0, ssh -o BatchMode=yes) so a clone fails fast instead of waiting on an invisible prompt.
Node.js prerequisite gate (bin/welcome.mjs, package.json, src/commands/preflight.ts): check process.versions.node before loading tsx/Ink and exit with a clear message if < 18 (static imports converted to dynamic so the gate runs first); add engines.node ">=18" for an npm/npx-level warning; surface a Node.js version check in the wizard preflight.
Why mise only (not asdf)

The attestation setting is mise-specific (python.github_attestations); asdf has no equivalent, so its python path is left untouched rather than guessing at a different mechanism.

Why the skills step stays non-fatal

Agent skills are optional. A failed or timed-out skill warns and the run continues, so one bad skill repo never blocks completing the rest of the setup.

### Test plan

npm run build (tsc), npm run lint, npm run format:check all pass.
Clone → --filter=blob:none produces a valid blobless partial clone; the retry loop retries, cleans up between attempts, backs off (5s→10s), and throws only after exhausting all attempts.
Python attestations → on current mise, mise settings set python.github_attestations false succeeds and reads back false; on a mise that doesn't know the key it warns and continues (no hard fail).
Agent-skills → a hung command is killed by the timeout (not waited out) and returns non-zero (→ non-fatal skip); the non-interactive git/SSH env reaches the child process.
Node gate → rejects Node 14/16 and garbage versions, accepts 18/22; preflight emits a Node.js result with the running version; node bin/welcome.mjs on Node ≥ 18 boots the wizard without hitting the gate.