### PR TITLE
Fix npx github install: silent exit + 'React is not defined'

### DIFF
--- a/bin/welcome.mjs
+++ b/bin/welcome.mjs
@@ -1,5 +1,15 @@
 #!/usr/bin/env node
 import { register } from 'tsx/esm/api'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+// tsx resolves tsconfig.json from the current working directory by default.
+// When run via `npx` from an arbitrary directory, it won't find this package's
+// tsconfig and falls back to the classic JSX transform (which needs `React` in
+// scope), so the app dies with "React is not defined". Point tsx at our own
+// tsconfig so the automatic JSX runtime ("jsx": "react-jsx") is always used.
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+process.env.TSX_TSCONFIG_PATH ??= join(packageRoot, 'tsconfig.json')
 
 // Register tsx loader so we can import .tsx files directly
 register()

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:fix": "eslint . --fix",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
-    "prepare": "lefthook install"
+    "prepare": "if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then lefthook install; fi"
   },
   "keywords": [
     "factorial",


### PR DESCRIPTION
## What

`npx github:factorialco/welcome#v1` — the command in our onboarding instructions — never launched the wizard. It exited **instantly with no output**. This PR fixes two chained bugs that block the primary distribution path.

## Root causes

**1. `prepare` script crashes git-dep preparation (silent exit)**

When npm installs a GitHub spec, it extracts the tarball to a non-git temp dir and runs `prepare` to build the package. Our `prepare` ran `lefthook install` unconditionally, which does `git rev-parse ...`:

```
> lefthook install
│  > git rev-parse --path-format=absolute --show-toplevel ...
│    fatal: not a git repository (or any of the parent directories): .git
npm error git dep preparation failed
npm error exit status 128
```

npm aborts with exit 1 **before `bin/welcome.mjs` runs**, and `npx` routes that failure to the debug log — so the user just sees an instant, silent return.

Fix: only run `lefthook install` when inside a git work tree; it's a no-op when consumed as a dependency.

**2. `React is not defined` on launch**

`tsx` reads `tsconfig.json` relative to the **current working directory**, not the package. Run via `npx` from an arbitrary dir, it never sees our `"jsx": "react-jsx"` setting and falls back to the classic JSX transform (`React.createElement`) — but our source uses the automatic runtime and doesn't import React, so the wizard crashes on the first render.

Fix: point tsx at the package's own tsconfig via `TSX_TSCONFIG_PATH`, resolved relative to the bin.

## Verification

Installed the branch as a git dependency and ran the bin from `$HOME` with no env vars (mirroring `npx github:`):

- **Before:** silent exit 1 (bug 1); after fixing bug 1, immediate `Fatal error: React is not defined` (bug 2).
- **After:** full wizard banner + welcome step render; zero errors.

## Follow-up

The `v1` tag points at an older commit. After merge, we should re-cut `v1` (and `v0`) to include these fixes, since the onboarding docs pin `#v1`.