### PR TITLE
fix: write mise/asdf PATH activation to shell profile, not just rc

### DIFF
--- a/src/commands/steps/05-version-manager.ts
+++ b/src/commands/steps/05-version-manager.ts
@@ -1,5 +1,5 @@
 import { type SetupConfig } from '../../context/index.js'
-import { getShellRc, getUserShell } from '../../platform.js'
+import { getShellProfile, getShellRc, getUserShell } from '../../platform.js'
 import { HOME, REPO_PATH } from '../constants.js'
 import {
   dirExists,
@@ -24,6 +24,7 @@ export async function runStep5(
     const plugins = ['rust', 'ruby', 'nodejs', 'python']
     const useMise = config.versionManager === 'mise'
     const shellRc = getShellRc()
+    const shellProfile = getShellProfile()
     const shell = getUserShell()
 
     // 0. Copy .factorialrc
@@ -38,7 +39,13 @@ export async function runStep5(
     if (useMise) {
       // 1. Add mise to PATH
       onProgress(1, 'Setting up mise version manager...')
+      // Also write to the profile (not just shellRc): sh()/sudoSh() run via a
+      // login shell, and on macOS that triggers path_helper, which pushes
+      // mise's shims behind /usr/bin. shellRc only loads for interactive
+      // shells, so it can't undo that; the profile loads for login shells
+      // either way and runs after path_helper.
       await ensureLine(shellRc, `eval "$(mise activate ${shell})"`)
+      await ensureLine(shellProfile, `eval "$(mise activate ${shell})"`)
 
       // 2-5. Install plugins
       for (let i = 0; i < plugins.length; i++) {
@@ -60,6 +67,9 @@ export async function runStep5(
       onProgress(1, 'Setting up asdf version manager...')
       const asdfPath = 'export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"'
       await ensureLine(shellRc, asdfPath)
+      // Same login-shell path_helper issue as the mise branch above: without
+      // this, asdf's shims lose out to /usr/bin in the wizard's own `sh()` calls.
+      await ensureLine(shellProfile, asdfPath)
 
       for (let i = 0; i < plugins.length; i++) {
         const plugin = plugins[i]!


### PR DESCRIPTION
## Problem

Step 13 (Setup development environment) fails on macOS with:

```
Could not find 'bundler' (2.5.11) required by your .../backend/Gemfile.lock. (Gem::GemNotFoundException)
```

even after installing that exact bundler version under mise's Ruby. It happens because `sh()`/`sudoSh()` run every command through a **login shell** (`zsh -lc`, see `getShellArgs()`). On macOS, login shells trigger `/etc/zprofile`'s `path_helper`, which unconditionally puts `/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin` ahead of whatever is already on `PATH` — demoting mise's (or asdf's) shims behind the OS-bundled Ruby's `gem`/`bundle`/`bundler` stubs living in `/usr/bin`.

Step 5 only writes the `mise activate`/asdf PATH line to `shellRc` (`~/.zshrc`), which is sourced **only by interactive shells**. Since the wizard's own commands run in a non-interactive login shell, `.zshrc` never re-runs to restore mise/asdf ahead of `/usr/bin`, so any step that shells out to `gem`/`bundle` (step 13) silently picks up the wrong Ruby toolchain.

## Fix

Also write the same activation line to the shell profile (`~/.zprofile` for zsh — the same file already used a few lines above for Homebrew's `shellenv`). The profile loads for login shells regardless of interactivity, and it's sourced *after* `path_helper`, so mise/asdf win there too.

## Verification

Reproduced and confirmed on macOS (zsh):

```sh
$ zsh -lc 'command -v bundle; bundle -v'
/usr/bin/bundle
Bundler version 1.17.2
```

After adding the activation line to `~/.zprofile`:

```sh
$ zsh -lc 'command -v bundle; bundle -v'
/Users/.../.local/share/mise/installs/ruby/3.4.8/bin/bundle
Bundler version 2.5.11
```

`npm run lint`, `npx tsc --noEmit`, and `oxfmt --check` all pass on the changed file.

Before adding the line the welcome script always failed as I already mencioned, once I add it manually the script succed and everything was installed correctly! :) 