### PR TITLE
Use the version manager Ruby in step 13, not the OS Ruby

### DIFF
--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -1,4 +1,5 @@
-import { getShellArgs, isDarwin } from '../platform.js'
+import type { VersionManager } from '../context/types.js'
+import { getShellArgs, getToolPathPrefix, isDarwin } from '../platform.js'
 import { LOG_FILE } from './constants.js'
 import { spawn, type ChildProcess } from 'node:child_process'
 import { constants, createWriteStream } from 'node:fs'
@@ -129,6 +130,16 @@ export async function sh(
     throw new Error(`Command failed (exit ${result.code}): ${command}${tail ? `\n${tail}` : ''}`)
   }
   return result
+}
+
+/**
+ * Build an `sh()` that runs its commands with the version manager's tools first
+ * on PATH — see getToolPathPrefix() for why the wizard cannot rely on the
+ * user's shell profile for this.
+ */
+export function makeShTool(vm: VersionManager): typeof sh {
+  const prefix = getToolPathPrefix(vm)
+  return (command, options) => sh(prefix + command, options)
 }
 
 /**

--- a/src/commands/steps/05-version-manager.ts
+++ b/src/commands/steps/05-version-manager.ts
@@ -6,6 +6,7 @@ import {
   ensureLine,
   fileExists,
   getErrorMessage,
+  makeShTool,
   sh,
   sudoSh,
   type ProgressCallback,
@@ -26,6 +27,9 @@ export async function runStep5(
     const shellRc = getShellRc()
     const shellProfile = getShellProfile()
     const shell = getUserShell()
+    // The version manager's own binary and the tools it installs must resolve
+    // without depending on how the login shell orders PATH.
+    const shTool = makeShTool(config.versionManager)
 
     // 0. Copy .factorialrc
     onProgress(0, 'Copying .factorialrc...')
@@ -50,18 +54,18 @@ export async function runStep5(
       // 2-5. Install plugins
       for (let i = 0; i < plugins.length; i++) {
         onProgress(i + 1, `Installing plugin: ${plugins[i]}...`)
-        await sh(`mise use -g "${plugins[i]}@latest"`, {
+        await shTool(`mise use -g "${plugins[i]}@latest"`, {
           env: { RUBY_CONFIGURE_OPTS: '--enable-yjit' },
         })
       }
 
       // 6. Install rust specific version
       onProgress(5, 'Installing Rust 1.96.0...')
-      await sh('mise use -g rust@1.96.0')
+      await shTool('mise use -g rust@1.96.0')
 
       // 7. Install all versions from repo
       onProgress(6, 'Installing all versions from .tool-versions...')
-      await sh('mise install', { cwd: REPO_PATH, interactive: true })
+      await shTool('mise install', { cwd: REPO_PATH, interactive: true })
     } else {
       // asdf
       onProgress(1, 'Setting up asdf version manager...')
@@ -74,19 +78,19 @@ export async function runStep5(
       for (let i = 0; i < plugins.length; i++) {
         const plugin = plugins[i]!
         onProgress(i + 1, `Installing plugin: ${plugin}...`)
-        const list = await sh('asdf plugin list')
+        const list = await shTool('asdf plugin list')
         if (list.stdout.includes(plugin)) {
-          await sh(`asdf plugin update ${plugin}`)
+          await shTool(`asdf plugin update ${plugin}`)
         } else {
-          await sh(`asdf plugin add ${plugin}`)
+          await shTool(`asdf plugin add ${plugin}`)
         }
       }
 
       onProgress(5, 'Installing Rust...')
-      await sh('asdf install rust', { env: { ASDF_RUST_VERSION: '1.96.0' } })
+      await shTool('asdf install rust', { env: { ASDF_RUST_VERSION: '1.96.0' } })
 
       onProgress(6, 'Installing all versions from .tool-versions...')
-      await sh('asdf install', { cwd: REPO_PATH, interactive: true })
+      await shTool('asdf install', { cwd: REPO_PATH, interactive: true })
 
       // Fix permissions — resolve username now because sudoSh on macOS runs as
       // root (where $(whoami) would return "root").

--- a/src/commands/steps/13-dev-environment.ts
+++ b/src/commands/steps/13-dev-environment.ts
@@ -1,8 +1,52 @@
 import { type SetupConfig } from '../../context/index.js'
+import type { VersionManager } from '../../context/types.js'
 import { getLibBuildFlags, isDarwin, isLinux } from '../../platform.js'
-import { BUNDLER_VERSION, PNPM_VERSION, REPO_PATH } from '../constants.js'
-import { getErrorMessage, sh, sudoSh, type ProgressCallback, type TaskResult } from '../helpers.js'
+import { BUNDLER_VERSION, HOME, PNPM_VERSION, REPO_PATH } from '../constants.js'
+import {
+  getErrorMessage,
+  makeShTool,
+  sudoSh,
+  type ProgressCallback,
+  type TaskResult,
+} from '../helpers.js'
+import { readFile } from 'node:fs/promises'
 import path from 'node:path'
+
+type ShTool = ReturnType<typeof makeShTool>
+
+/**
+ * Bundler version the backend's lockfile asks for. The pinned constant is only
+ * a fallback: reading `BUNDLED WITH` keeps this working when the monorepo bumps
+ * bundler ahead of the version pinned here.
+ */
+async function resolveBundlerVersion(backendCwd: string): Promise<string> {
+  try {
+    const lock = await readFile(path.join(backendCwd, 'Gemfile.lock'), 'utf-8')
+    return /BUNDLED WITH\s+([\d.]+)/.exec(lock)?.[1] ?? BUNDLER_VERSION
+  } catch {
+    return BUNDLER_VERSION
+  }
+}
+
+/**
+ * Refuse to continue on an OS-bundled Ruby. Every gem and bundle command below
+ * would otherwise appear to work and then fail several commands later inside
+ * bundler, with a message that says nothing about PATH.
+ */
+async function assertManagedRuby(shTool: ShTool, versionManager: VersionManager): Promise<void> {
+  const rubyPath = (await shTool('command -v ruby')).stdout.trim()
+  const rubyVersion = (await shTool(`ruby -e 'print RUBY_VERSION'`)).stdout.trim()
+  const major = Number(rubyVersion.split('.')[0])
+
+  if (!rubyPath || !Number.isFinite(major) || major < 3) {
+    const found = rubyPath ? `${rubyPath}${rubyVersion ? ` (${rubyVersion})` : ''}` : 'no ruby'
+    throw new Error(
+      `Ruby from ${versionManager} is not on PATH. Found: ${found}. ` +
+        `Complete the version manager step first. Then make sure the ${versionManager} ` +
+        `activation line is in your shell profile.`
+    )
+  }
+}
 
 /** Step 13: Setup development environment */
 export async function runStep13(
@@ -11,30 +55,54 @@ export async function runStep13(
 ): Promise<TaskResult> {
   const start = Date.now()
   try {
+    // Every command here needs the version manager's toolchain (ruby, node,
+    // python) rather than whatever the login shell's PATH resolves to.
+    const shTool = makeShTool(config.versionManager)
+    const backendCwd = path.join(REPO_PATH, 'backend')
+    const reshim = config.versionManager === 'mise' ? 'mise reshim || true' : 'asdf reshim || true'
+
+    // Regenerate shims first: gem binstubs from an earlier partial run only
+    // become callable after a reshim.
+    await shTool(reshim)
+    await assertManagedRuby(shTool, config.versionManager)
+
     // 0. Install yarn/pnpm and run pnpm i
     onProgress(0, 'Installing yarn and pnpm globally...')
-    await sh(`npm install --global yarn pnpm@${PNPM_VERSION}`, {
+    await shTool(`npm install --global yarn pnpm@${PNPM_VERSION}`, {
       interactive: true,
     })
+    await shTool(reshim)
 
     onProgress(1, 'Running pnpm install...')
-    await sh('pnpm i', { cwd: REPO_PATH, interactive: true })
+    await shTool('pnpm i', { cwd: REPO_PATH, interactive: true })
 
     // 1. Install bundler + bundle install
     onProgress(2, 'Installing bundler and running bundle install...')
-    const gemPath = (await sh('command -v gem')).stdout
-    const isUserGem = gemPath.includes(process.env.USER || '')
-    if (isUserGem) {
-      await sh(`gem install bundler -v "${BUNDLER_VERSION}"`, {
-        cwd: path.join(REPO_PATH, 'backend'),
+    const bundlerVersion = await resolveBundlerVersion(backendCwd)
+    const gemDirWritable = (await shTool('[ -w "$(gem env gemdir)" ]')).code === 0
+    if (gemDirWritable) {
+      await shTool(`gem install bundler -v "${bundlerVersion}"`, {
+        cwd: backendCwd,
+        check: true,
       })
     } else {
-      // System gem requires elevated privileges
-      await sudoSh(`gem install bundler -v '${BUNDLER_VERSION}'`)
+      // A system-owned gem dir needs root. Fail loud on a bad exit code: a
+      // swallowed failure here comes back later as a confusing bundler error.
+      const sudoGem = await sudoSh(`gem install bundler -v '${bundlerVersion}'`)
+      if (sudoGem.code !== 0) {
+        const tail = (sudoGem.stderr || sudoGem.stdout).split('\n').slice(-15).join('\n')
+        throw new Error(
+          `Failed to install bundler ${bundlerVersion} into the system gem dir (exit ${sudoGem.code})` +
+            `${tail ? `\n${tail}` : ''}`
+        )
+      }
     }
+    await shTool(reshim)
+    await shTool(`gem list -i -v "${bundlerVersion}" bundler`, { check: true })
+    await shTool('bundle --version', { cwd: backendCwd, check: true })
 
     // mysql2 gem with library flags (platform-aware)
-    const buildFlags = await getLibBuildFlags((cmd) => sh(cmd))
+    const buildFlags = await getLibBuildFlags((cmd) => shTool(cmd))
 
     // Safety net for the native build: export LIBRARY_PATH so the linker finds
     // libzstd/openssl even if the explicit --with-ldflags don't take effect.
@@ -51,22 +119,26 @@ export async function runStep13(
     // both the standalone gem install and bundle install pick up the right flags.
     // Needed on all macOS (not just ARM) with MySQL 9.x which requires zstd.
     if (isDarwin() || isLinux()) {
-      await sh(
+      // `--global` writes to ~/.bundle/config, so the working directory does not
+      // change the outcome — but running it inside the repo makes bundler load
+      // Gemfile.lock first, which turns any bundler mismatch into a failure here.
+      await shTool(
         `bundle config set --global build.mysql2 "--with-opt-dir=${buildFlags.optDir} --with-ldflags=${buildFlags.ldflags} --with-cppflags=${buildFlags.cppflags}"`,
-        { cwd: path.join(REPO_PATH, 'backend'), check: true }
+        { cwd: HOME, check: true }
       )
     }
 
-    await sh(
+    await shTool(
       `gem install mysql2 -- --with-opt-dir="${buildFlags.optDir}" --with-ldflags="${buildFlags.ldflags}" --with-cppflags="${buildFlags.cppflags}"`,
-      { cwd: path.join(REPO_PATH, 'backend'), env: buildEnv, check: true }
+      { cwd: backendCwd, env: buildEnv, check: true }
     )
 
     // tmuxinator (terminal multiplexer session manager)
-    await sh('gem install tmuxinator')
+    await shTool('gem install tmuxinator')
+    await shTool(reshim)
 
-    await sh('bundle install', {
-      cwd: path.join(REPO_PATH, 'backend'),
+    await shTool('bundle install', {
+      cwd: backendCwd,
       interactive: true,
       env: buildEnv,
       check: true,
@@ -74,27 +146,27 @@ export async function runStep13(
 
     // 2. Mobile + ATS deps
     onProgress(3, 'Installing mobile and ATS dependencies...')
-    await sh('pnpm i', {
+    await shTool('pnpm i', {
       cwd: path.join(REPO_PATH, 'mobile'),
       interactive: true,
     })
-    await sh('yarn install', {
+    await shTool('yarn install', {
       cwd: path.join(REPO_PATH, 'backend', 'components', 'ats'),
       interactive: true,
     })
 
     // 3. Shadowdog
     onProgress(4, 'Running shadowdog...')
-    await sh('pnpm shadowdog', { cwd: REPO_PATH, interactive: true })
+    await shTool('pnpm shadowdog', { cwd: REPO_PATH, interactive: true })
 
     // 4. Docker compose — detect modern plugin vs legacy standalone
     const composeCmd = await (async () => {
       try {
-        await sh('docker compose version', { cwd: REPO_PATH, check: true })
+        await shTool('docker compose version', { cwd: REPO_PATH, check: true })
         return 'docker compose'
       } catch {
         try {
-          await sh('docker-compose --version', { cwd: REPO_PATH, check: true })
+          await shTool('docker-compose --version', { cwd: REPO_PATH, check: true })
           onProgress(
             5,
             '⚠ Legacy docker-compose detected. Consider upgrading to the Docker Compose plugin (docker compose).'
@@ -110,7 +182,7 @@ export async function runStep13(
 
     onProgress(5, 'Starting docker compose...')
     const composeCwd = path.join(REPO_PATH, '.local-dev')
-    await sh(`direnv exec "${composeCwd}" ${composeCmd} up -d --force-recreate`, {
+    await shTool(`direnv exec "${composeCwd}" ${composeCmd} up -d --force-recreate`, {
       cwd: composeCwd,
       interactive: true,
       env: { REPO_ROOT: REPO_PATH },
@@ -123,7 +195,7 @@ export async function runStep13(
     // (When the profile is dropped from the compose file, this can fold into
     // the main `up` above.)
     onProgress(6, 'Starting Conductor services (conductor-postgres, conductor)...')
-    const conductorUp = await sh(
+    const conductorUp = await shTool(
       `direnv exec "${composeCwd}" ${composeCmd} up -d conductor-postgres conductor`,
       { cwd: composeCwd, interactive: true, env: { REPO_ROOT: REPO_PATH } }
     )
@@ -137,7 +209,7 @@ export async function runStep13(
     const retryInterval = 15
     let mysqlHealthy = false
     for (let i = 0; i < maxRetries; i++) {
-      const containerId = await sh(
+      const containerId = await shTool(
         `direnv exec "${composeCwd}" ${composeCmd} ps -q mysql 2>/dev/null || echo ""`,
         {
           cwd: composeCwd,
@@ -146,7 +218,7 @@ export async function runStep13(
       )
       const cid = containerId.stdout.trim()
       if (cid) {
-        const health = await sh(
+        const health = await shTool(
           `docker inspect --format='{{.State.Health.Status}}' ${cid} 2>/dev/null || echo "starting"`,
           { cwd: composeCwd }
         )
@@ -165,14 +237,14 @@ export async function runStep13(
     // 6. DB restore or create
     if (config.restoreDb) {
       onProgress(7, 'Restoring database from backup...')
-      await sh(
+      await shTool(
         'bundle exec rails db:drop db:create db:seeds:restore db:migrate:with_data dev:enable_default_features db:test:prepare',
-        { cwd: path.join(REPO_PATH, 'backend'), interactive: true, check: true }
+        { cwd: backendCwd, interactive: true, check: true }
       )
     } else {
       onProgress(7, 'Creating database...')
-      await sh('bundle exec rails db:create db:migrate db:test:prepare', {
-        cwd: path.join(REPO_PATH, 'backend'),
+      await shTool('bundle exec rails db:create db:migrate db:test:prepare', {
+        cwd: backendCwd,
         interactive: true,
         check: true,
       })
@@ -182,16 +254,18 @@ export async function runStep13(
     // actually usable. Each check is fail-loud (`check: true`) so a failure here
     // surfaces as a red task with a real error instead of a false ✓.
     onProgress(7, 'Verifying environment...')
-    const backendCwd = path.join(REPO_PATH, 'backend')
 
     // 7a. The mysql2 native extension actually loads (zstd/openssl linked OK),
     //     not just that `gem install` reported success.
-    await sh(`bundle exec ruby -e "require 'mysql2'"`, { cwd: backendCwd, check: true })
+    await shTool(`bundle exec ruby -e "require 'mysql2'"`, { cwd: backendCwd, check: true })
 
     // 7b. The database is reachable AND has no pending migrations. This single
     //     rake task must connect to read schema_migrations, so it covers both
     //     "DB exists/reachable" and "schema is up to date" in one Rails boot.
-    await sh('bundle exec rails db:abort_if_pending_migrations', { cwd: backendCwd, check: true })
+    await shTool('bundle exec rails db:abort_if_pending_migrations', {
+      cwd: backendCwd,
+      check: true,
+    })
 
     // 8. Done — no editor or browser opened; the finished pane shows next steps
 

--- a/src/commands/steps/14-agent-skills.ts
+++ b/src/commands/steps/14-agent-skills.ts
@@ -1,6 +1,6 @@
 import { type SetupConfig } from '../../context/index.js'
 import { SKILL_REPOS } from '../constants.js'
-import { getErrorMessage, sh, type ProgressCallback, type TaskResult } from '../helpers.js'
+import { getErrorMessage, makeShTool, type ProgressCallback, type TaskResult } from '../helpers.js'
 
 /** Step 14: Install agent skills */
 export async function runStep14(
@@ -9,10 +9,14 @@ export async function runStep14(
 ): Promise<TaskResult> {
   const start = Date.now()
   try {
+    // npx must come from the managed Node, not from whatever the login shell's
+    // PATH resolves to.
+    const shTool = makeShTool(config.versionManager)
+
     for (let i = 0; i < SKILL_REPOS.length; i++) {
       const repo = SKILL_REPOS[i]!
       onProgress(i, `npx skills add ${repo}...`)
-      const result = await sh(`npx --yes skills add "${repo}" -g -y`, {
+      const result = await shTool(`npx --yes skills add "${repo}" -g -y`, {
         interactive: true,
       })
       if (result.code !== 0) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,3 +1,4 @@
+import type { VersionManager } from './context/types.js'
 import { readFile } from 'node:fs/promises'
 import { platform as osPlatform, arch as osArch } from 'node:os'
 import { homedir } from 'node:os'
@@ -106,6 +107,26 @@ export function getShellRc(): string {
   const shell = getUserShell()
   if (shell === 'zsh') return path.join(home, '.zshrc')
   return path.join(home, '.bashrc')
+}
+
+/**
+ * Shell snippet that puts the version manager's tools first on PATH.
+ *
+ * Commands run through a login shell, and on macOS path_helper (/etc/zprofile)
+ * rebuilds PATH with the system directories first. That demotes the shims a
+ * user profile added behind /usr/bin, so `ruby`/`gem`/`bundle` resolve to the
+ * OS-bundled Ruby. Prepending inside the command itself runs after the profile,
+ * so it wins whatever the dotfiles look like.
+ *
+ * The Homebrew directories are here so `mise`/`asdf` themselves resolve; PATH
+ * entries that do not exist are ignored.
+ */
+export function getToolPathPrefix(vm: VersionManager): string {
+  const shimsDir =
+    vm === 'mise'
+      ? '${MISE_DATA_DIR:-$HOME/.local/share/mise}/shims:$HOME/.local/bin'
+      : '${ASDF_DATA_DIR:-$HOME/.asdf}/shims'
+  return `export PATH="${shimsDir}:/opt/homebrew/bin:/usr/local/bin:$PATH"; `
 }
 
 // ── Cross-Platform Command Equivalents ─────────────────


### PR DESCRIPTION
## Problem

Step 13 (`Setup development environment`) fails with:

```
Command failed (exit 1): bundle config set --global build.mysql2 "..."
/System/.../Ruby.framework/Versions/2.6/.../rubygems.rb:283:in `find_spec_for_exe':
Could not find 'bundler' (2.5.11) required by your .../backend/Gemfile.lock
```

The message points at bundler, but the cause is PATH.

## Cause

`sh()` runs every command through a login shell (`zsh -lc`). On macOS, `path_helper`
in `/etc/zprofile` rebuilds PATH with `/etc/paths` and `/etc/paths.d` first and
appends everything else. Shims that a user profile added end up behind `/usr/bin`,
so `ruby`, `gem` and `bundle` resolve to the OS-bundled Ruby 2.6. This is
reproducible: `~/.asdf/shims` is on the login-shell PATH, yet
`zsh -lc 'command -v ruby'` returns `/usr/bin/ruby` (2.6.10).

Step 13 then took the wrong branch. `command -v gem` returned `/usr/bin/gem`, so
the `isUserGem` heuristic (does the path contain `$USER`?) was false, and the
wizard ran `sudo gem install bundler -v 2.5.11` against Ruby 2.6. Bundler 2.5
needs Ruby 3.0 or later, so the install failed. `sudoSh`'s exit code was never
checked, so the run continued and stopped two commands later, at the first command
with `check: true`.

Commit c91f559 attacked the same problem by writing the activation line to
`~/.zprofile`. That helps the user's own terminals, but the wizard still depends
on dotfile ordering. This change removes that dependency.

## Changes

- `getToolPathPrefix()` (platform.ts) and `makeShTool()` (helpers.ts) put the
  version manager shims first inside each command, so the result does not depend
  on the user's dotfiles. Steps 5, 13 and 14 use it. `sh()` and `sudoSh()` are
  unchanged.
- Step 13 stops before any gem work when Ruby is missing or older than 3.0, and
  the error names the Ruby it found.
- A write test on the real gem directory (`[ -w "$(gem env gemdir)" ]`) replaces
  the `isUserGem` heuristic.
- The elevated `gem install bundler` now fails loud.
- Bundler is verified after the install (`gem list -i`, `bundle --version`).
- The bundler version comes from `backend/Gemfile.lock` (`BUNDLED WITH`).
  `BUNDLER_VERSION` is now only a fallback.
- The global bundle config runs from `HOME`, so the repository lockfile cannot
  gate a write that goes to `~/.bundle/config`.
- A reshim runs after each gem install, so new binstubs are callable.

## Verification

- `npm run lint`, `npm run format:check`, `npm run build`: clean.
- PATH mechanism, on an affected machine:
  `zsh -lc 'command -v ruby; ruby -v'` gives `/usr/bin/ruby` 2.6.10.
  The same command with the new prefix gives the asdf Ruby 3.3.5 and
  `~/.asdf/shims/bundle`.
- `makeShTool('asdf')` resolves Ruby 3.3.5 and reports the gem dir as writable
  (no `sudo` branch).
- Negative path: `runStep13` with a version manager that is not installed returns
  `Ruby from mise is not on PATH. Found: /usr/bin/ruby (2.6.10). …` and runs no
  destructive command.
- `BUNDLED WITH` parsing returns 2.5.11 from the current monorepo lockfile and
  falls back when the file is missing.
- Not verified: a full step 13 run end to end. That needs an affected machine with
  the monorepo cloned (run the wizard, or press `r` to retry the failed task).

## Workaround for anyone blocked now

```bash
eval "$(mise activate zsh)" && gem install bundler -v 2.5.11
```

Then press `r` to retry the failed task. With asdf:

```bash
export PATH="$HOME/.asdf/shims:$PATH" && gem install bundler -v 2.5.11 && asdf reshim ruby
```
